### PR TITLE
Add setter to udpate assertion policy setting

### DIFF
--- a/contracts/uma/EscalationManager.sol
+++ b/contracts/uma/EscalationManager.sol
@@ -12,6 +12,11 @@ contract EscalationManager is EscalationManagerInterface, AccessControl{
 
     OptimisticOracleV3Interface public immutable optimisticOracleV3;
 
+    bool public blockAssertion;
+    bool public arbitrateViaEscalationManager;
+    bool public discardOracle;
+    bool public validateDisputers;
+
     mapping (address => bool) checkDisputers;
     mapping (address => bool) checkAssertingCaller;
 
@@ -21,6 +26,11 @@ contract EscalationManager is EscalationManagerInterface, AccessControl{
     }
 
     event PriceRequestAdded(bytes32 indexed identifier, uint256 time, bytes ancillaryData);
+    event UpdatedBlockAssertion(address indexed owner, bool blockAssertion);
+    event UpdatedArbitrateViaEscalationManager(address indexed owner, bool arbitrateViaEscalationManager);
+    event UpdatedDiscardOracle(address indexed owner, bool discardOracle);
+    event UpdatedValidateDisputers(address indexed owner, bool validateDisputers);
+    
 
     /**
      * @notice Constructs the escalation manager.
@@ -34,17 +44,41 @@ contract EscalationManager is EscalationManagerInterface, AccessControl{
         _setRoleAdmin(OPTMISTIC_ORACLE_V3_ROLE, CLAIM_ASSESSOR_ROLE);
     }
     
-    function getAssertionPolicy(bytes32) external override pure returns (AssertionPolicy memory) {
+    function getAssertionPolicy(bytes32) external override view returns (AssertionPolicy memory) {
         return AssertionPolicy({
-            blockAssertion: false,
-            arbitrateViaEscalationManager: true,
-            discardOracle: true,
-            validateDisputers: true
+            blockAssertion: blockAssertion,
+            arbitrateViaEscalationManager: arbitrateViaEscalationManager,
+            discardOracle: discardOracle,
+            validateDisputers: validateDisputers
         });
     }
 
     function isDisputeAllowed(bytes32 assertionId, address disputeCaller) external override view returns (bool) {
         return checkDisputers[disputeCaller];
+    }
+
+    function setBlockAssertion(bool _blockAssertion) external onlyRole(CLAIM_ASSESSOR_ROLE) {
+        blockAssertion = _blockAssertion;
+
+        emit UpdatedBlockAssertion(msg.sender, _blockAssertion);
+    }
+
+    function setArbitrateViaEscalationManager(bool _arbitrateViaEscalationManager) external onlyRole(CLAIM_ASSESSOR_ROLE) {
+        arbitrateViaEscalationManager = _arbitrateViaEscalationManager;
+
+        emit UpdatedArbitrateViaEscalationManager(msg.sender, _arbitrateViaEscalationManager);
+    }
+
+    function setDiscardOracle(bool _discardOracle) external onlyRole(CLAIM_ASSESSOR_ROLE) {
+        discardOracle = _discardOracle;
+
+        emit UpdatedDiscardOracle(msg.sender, _discardOracle);
+    }
+
+    function setValidateDisputers(bool _validateDisputers) external onlyRole(CLAIM_ASSESSOR_ROLE) {
+        validateDisputers = _validateDisputers;
+
+        emit UpdatedValidateDisputers(msg.sender, _validateDisputers);
     }
 
     function toggleDisputer(address _disputer) external onlyRole(CLAIM_ASSESSOR_ROLE) {


### PR DESCRIPTION
Spec discussion: 

- claim assessor can change setting of assertion policy
- default setting is escalation manager will handle disputer, assertions verification, claim assessor can change this setting 