### PR TITLE
Update override functions to settle and reject policy 

### DIFF
--- a/contracts/interfaces/IPayoutRequest.sol
+++ b/contracts/interfaces/IPayoutRequest.sol
@@ -2,5 +2,14 @@
 pragma solidity =0.8.23;
 
 interface IPayoutRequest {
+    struct Policy {
+        uint256 insuranceAmount;
+        address payoutAddress;
+        bool settled;
+    }
+
     function assertionResolvedCallback(bytes32 _assertionId, bool _assertedTruthfully) external;
+    function policies(uint256 _policyId) external view returns(Policy memory);
+    function assertedPolicies(bytes32 _assertionId) external view returns(uint256);
+    function ssip() external view returns(address);
 }


### PR DESCRIPTION
Spec discussion: 

- esacalation manager can reject policy if dvm approves or accept policy if dvm rejects .